### PR TITLE
Add BLOB_TREE object type

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1191,6 +1191,7 @@ LIB_OBJS += transport.o
 LIB_OBJS += tree-diff.o
 LIB_OBJS += tree-walk.o
 LIB_OBJS += tree.o
+LIB_OBJS += blob-tree.o
 LIB_OBJS += unpack-trees.o
 LIB_OBJS += upload-pack.o
 LIB_OBJS += url.o

--- a/alloc.c
+++ b/alloc.c
@@ -12,6 +12,7 @@
 #include "object.h"
 #include "blob.h"
 #include "tree.h"
+#include "blob-tree.h"
 #include "commit.h"
 #include "repository.h"
 #include "tag.h"
@@ -20,11 +21,12 @@
 #define BLOCKING 1024
 
 union any_object {
-	struct object object;
-	struct blob blob;
-	struct tree tree;
-	struct commit commit;
-	struct tag tag;
+        struct object object;
+        struct blob blob;
+        struct tree tree;
+        struct blob_tree blob_tree;
+        struct commit commit;
+        struct tag tag;
 };
 
 struct alloc_state {
@@ -79,9 +81,17 @@ void *alloc_blob_node(struct repository *r)
 
 void *alloc_tree_node(struct repository *r)
 {
-	struct tree *t = alloc_node(r->parsed_objects->tree_state, sizeof(struct tree));
-	t->object.type = OBJ_TREE;
-	return t;
+        struct tree *t = alloc_node(r->parsed_objects->tree_state, sizeof(struct tree));
+        t->object.type = OBJ_TREE;
+        return t;
+}
+
+void *alloc_blob_tree_node(struct repository *r)
+{
+        struct blob_tree *t = alloc_node(r->parsed_objects->blob_tree_state,
+                                         sizeof(struct blob_tree));
+        t->object.type = OBJ_BLOB_TREE;
+        return t;
 }
 
 void *alloc_tag_node(struct repository *r)

--- a/alloc.h
+++ b/alloc.h
@@ -9,6 +9,7 @@ struct repository;
 
 void *alloc_blob_node(struct repository *r);
 void *alloc_tree_node(struct repository *r);
+void *alloc_blob_tree_node(struct repository *r);
 void init_commit_node(struct commit *c);
 void *alloc_commit_node(struct repository *r);
 void *alloc_tag_node(struct repository *r);

--- a/blob-tree.c
+++ b/blob-tree.c
@@ -1,0 +1,136 @@
+#define USE_THE_REPOSITORY_VARIABLE
+
+#include "git-compat-util.h"
+#include "blob-tree.h"
+#include "object-file.h"
+#include "hex.h"
+#include "object-name.h"
+#include "object-store.h"
+#include "alloc.h"
+#include "tree-walk.h"
+#include "repository.h"
+#include "environment.h"
+
+const char *blob_tree_type = "blob-tree";
+
+struct blob_tree *lookup_blob_tree(struct repository *r, const struct object_id *oid)
+{
+        struct object *obj = lookup_object(r, oid);
+        if (!obj)
+                return create_object(r, oid, alloc_blob_tree_node(r));
+        return object_as_type(obj, OBJ_BLOB_TREE, 0);
+}
+
+int parse_blob_tree_buffer(struct blob_tree *item, void *buffer, unsigned long size)
+{
+        if (item->object.parsed)
+                return 0;
+        item->object.parsed = 1;
+        item->buffer = buffer;
+        item->size = size;
+        return 0;
+}
+
+int parse_blob_tree_gently(struct blob_tree *item, int quiet_on_missing)
+{
+        enum object_type type;
+        void *buffer;
+        unsigned long size;
+
+        if (item->object.parsed)
+                return 0;
+        buffer = repo_read_object_file(the_repository, &item->object.oid,
+                                       &type, &size);
+        if (!buffer)
+                return quiet_on_missing ? -1 :
+                        error("Could not read %s",
+                             oid_to_hex(&item->object.oid));
+        if (type != OBJ_BLOB_TREE) {
+                free(buffer);
+                return error("Object %s not a blob tree",
+                             oid_to_hex(&item->object.oid));
+        }
+        return parse_blob_tree_buffer(item, buffer, size);
+}
+
+void free_blob_tree_buffer(struct blob_tree *tree)
+{
+        FREE_AND_NULL(tree->buffer);
+        tree->size = 0;
+        tree->object.parsed = 0;
+}
+
+struct blob_tree *parse_blob_tree_indirect(const struct object_id *oid)
+{
+        struct repository *r = the_repository;
+        struct object *obj = parse_object(r, oid);
+        return (struct blob_tree *)repo_peel_to_type(r, NULL, 0, obj, OBJ_BLOB_TREE);
+}
+
+
+#define CHUNK_MASK 0x1fff
+
+static uint32_t roll_hash(uint32_t hash, unsigned char c)
+{
+        return ((hash << 5) ^ c) & 0xffffffff;
+}
+
+int write_blob_tree_fd(int fd, struct object_id *oid)
+{
+        struct strbuf chunk = STRBUF_INIT;
+        struct strbuf tree_buf = STRBUF_INIT;
+        ssize_t n;
+        unsigned char buf[8192];
+        uint32_t h = 0;
+        while ((n = xread(fd, buf, sizeof(buf))) > 0) {
+                ssize_t i;
+                for (i = 0; i < n; i++) {
+                        strbuf_addch(&chunk, buf[i]);
+                        h = roll_hash(h, buf[i]);
+                        if ((h & CHUNK_MASK) == CHUNK_MASK || chunk.len > 65536) {
+                                struct object_id c_oid;
+                                if (write_object_file(chunk.buf, chunk.len, OBJ_BLOB, &c_oid)) {
+                                        strbuf_release(&chunk);
+                                        strbuf_release(&tree_buf);
+                                        return -1;
+                                }
+                                strbuf_addf(&tree_buf, "%s\n", oid_to_hex(&c_oid));
+                                strbuf_reset(&chunk);
+                                h = 0;
+                        }
+                }
+        }
+        if (n < 0) {
+                strbuf_release(&chunk);
+                strbuf_release(&tree_buf);
+                return -1;
+        }
+        if (chunk.len) {
+                struct object_id c_oid;
+                if (write_object_file(chunk.buf, chunk.len, OBJ_BLOB, &c_oid)) {
+                        strbuf_release(&chunk);
+                        strbuf_release(&tree_buf);
+                        return -1;
+                }
+                strbuf_addf(&tree_buf, "%s\n", oid_to_hex(&c_oid));
+        }
+        strbuf_release(&chunk);
+        if (write_object_file(tree_buf.buf, tree_buf.len, OBJ_BLOB_TREE, oid)) {
+                strbuf_release(&tree_buf);
+                return -1;
+        }
+        strbuf_release(&tree_buf);
+        return 0;
+}
+
+int write_blob_tree_file(const char *path, struct object_id *oid)
+{
+        int fd = open(path, O_RDONLY);
+        int ret;
+        if (fd < 0)
+                return error_errno("open('%s')", path);
+        ret = write_blob_tree_fd(fd, oid);
+        close(fd);
+        return ret;
+}
+

--- a/blob-tree.h
+++ b/blob-tree.h
@@ -1,0 +1,31 @@
+#ifndef BLOB_TREE_H
+#define BLOB_TREE_H
+
+#include "object.h"
+
+struct repository;
+struct strbuf;
+
+struct blob_tree {
+        struct object object;
+        void *buffer;
+        unsigned long size;
+};
+
+extern const char *blob_tree_type;
+
+struct blob_tree *lookup_blob_tree(struct repository *r, const struct object_id *oid);
+int parse_blob_tree_buffer(struct blob_tree *item, void *buffer, unsigned long size);
+int parse_blob_tree_gently(struct blob_tree *tree, int quiet_on_missing);
+static inline int parse_blob_tree(struct blob_tree *tree)
+{
+        return parse_blob_tree_gently(tree, 0);
+}
+void free_blob_tree_buffer(struct blob_tree *tree);
+struct blob_tree *parse_blob_tree_indirect(const struct object_id *oid);
+
+
+int write_blob_tree_fd(int fd, struct object_id *oid);
+int write_blob_tree_file(const char *path, struct object_id *oid);
+
+#endif /* BLOB_TREE_H */

--- a/builtin/add.c
+++ b/builtin/add.c
@@ -388,8 +388,8 @@ int cmd_add(int argc,
 
 	repo_config(repo, add_config, NULL);
 
-	argc = parse_options(argc, argv, prefix, builtin_add_options,
-			  builtin_add_usage, PARSE_OPT_KEEP_ARGV0);
+       argc = parse_options(argc, argv, prefix, builtin_add_options,
+                         builtin_add_usage, PARSE_OPT_KEEP_ARGV0);
 
 	prepare_repo_settings(repo);
 	repo->settings.command_requires_full_index = 0;

--- a/object-file.c
+++ b/object-file.c
@@ -21,6 +21,7 @@
 #include "loose.h"
 #include "object-file-convert.h"
 #include "object-file.h"
+#include "blob-tree.h"
 #include "object-store.h"
 #include "oidtree.h"
 #include "pack.h"
@@ -1281,21 +1282,18 @@ int index_fd(struct index_state *istate, struct object_id *oid,
 }
 
 int index_path(struct index_state *istate, struct object_id *oid,
-	       const char *path, struct stat *st, unsigned flags)
+               const char *path, struct stat *st, unsigned flags)
 {
-	int fd;
-	struct strbuf sb = STRBUF_INIT;
-	int rc = 0;
+       struct strbuf sb = STRBUF_INIT;
+       int rc = 0;
 
 	switch (st->st_mode & S_IFMT) {
-	case S_IFREG:
-		fd = open(path, O_RDONLY);
-		if (fd < 0)
-			return error_errno("open(\"%s\")", path);
-		if (index_fd(istate, oid, fd, st, OBJ_BLOB, path, flags) < 0)
-			return error(_("%s: failed to insert into database"),
-				     path);
-		break;
+       case S_IFREG:
+               rc = write_blob_tree_file(path, oid);
+               if (rc < 0)
+                       return error(_("%s: failed to insert into database"),
+                                    path);
+               break;
 	case S_IFLNK:
 		if (strbuf_readlink(&sb, path, st->st_size))
 			return error_errno("readlink(\"%s\")", path);

--- a/object.h
+++ b/object.h
@@ -12,9 +12,10 @@ struct parsed_object_pool {
 	int nr_objs, obj_hash_size;
 
 	/* TODO: migrate alloc_states to mem-pool? */
-	struct alloc_state *blob_state;
-	struct alloc_state *tree_state;
-	struct alloc_state *commit_state;
+        struct alloc_state *blob_state;
+        struct alloc_state *tree_state;
+        struct alloc_state *blob_tree_state;
+        struct alloc_state *commit_state;
 	struct alloc_state *tag_state;
 	struct alloc_state *object_state;
 
@@ -99,13 +100,13 @@ enum object_type {
 	OBJ_NONE = 0,
 	OBJ_COMMIT = 1,
 	OBJ_TREE = 2,
-	OBJ_BLOB = 3,
-	OBJ_TAG = 4,
-	/* 5 for future expansion */
-	OBJ_OFS_DELTA = 6,
-	OBJ_REF_DELTA = 7,
-	OBJ_ANY,
-	OBJ_MAX
+       OBJ_BLOB = 3,
+       OBJ_TAG = 4,
+       OBJ_BLOB_TREE = 5,
+       OBJ_OFS_DELTA = 6,
+       OBJ_REF_DELTA = 7,
+       OBJ_ANY,
+       OBJ_MAX
 };
 
 /* unknown mode (impossible combination S_IFIFO|S_IFCHR) */

--- a/t/meson.build
+++ b/t/meson.build
@@ -1097,6 +1097,7 @@ integration_tests = [
   't9901-git-web--browse.sh',
   't9902-completion.sh',
   't9903-bash-prompt.sh',
+  't9999-blob-tree.sh',
 ]
 
 benchmarks = [

--- a/t/t9999-blob-tree.sh
+++ b/t/t9999-blob-tree.sh
@@ -1,0 +1,19 @@
+#!/bin/sh
+
+test_description='blob tree object type'
+
+. ./test-lib.sh
+
+test_expect_success 'add creates blob-tree' '
+ echo "hello world" >file &&
+ git add file &&
+ oid=$(git ls-files -s file | cut -d" " -f2) &&
+ test "$(git cat-file -t $oid)" = "blob-tree" &&
+ git cat-file -p $oid >chunks &&
+ test -s chunks &&
+ while read ch; do
+  test "$(git cat-file -t $ch)" = "blob" || return 1
+ done <chunks
+'
+
+test_done


### PR DESCRIPTION
## Summary
- introduce new `OBJ_BLOB_TREE` object type
- implement blob-tree object handling code
- allocate and clean up blob-tree objects via parsed object pool
- chunk files added via `git add` into blob-tree objects
- test blob-tree creation
- use blob trees by default
- include blob tree test in meson build

## Testing
- `make blob-tree.o object-file.o builtin/add.o`
- `make test` *(fails: 14 of 92 tests)*

------
https://chatgpt.com/codex/tasks/task_e_68582236f02c8324b710ed8a2f486eea